### PR TITLE
feat: Minecraft for 1.20.5 requires Java 21 (and not 1.21)

### DIFF
--- a/lib/common/distribution/DistributionFactory.ts
+++ b/lib/common/distribution/DistributionFactory.ts
@@ -131,7 +131,7 @@ export class HeliosServer {
     }
 
     private defaultJavaVersion(): [string, number] {
-        if(mcVersionAtLeast('1.21', this.rawServer.minecraftVersion)) {
+        if(mcVersionAtLeast('1.20.5', this.rawServer.minecraftVersion)) {
             return ['>=21.x', 21]
         } else if(mcVersionAtLeast('1.17', this.rawServer.minecraftVersion)) {
             return ['>=17.x', 17]

--- a/lib/common/util/MojangUtils.ts
+++ b/lib/common/util/MojangUtils.ts
@@ -1,4 +1,5 @@
 import { Rule, Natives } from '../../dl/mojang/MojangTypes'
+import semver from 'semver'
 
 export function getMojangOS(): string {
     const opSys = process.platform
@@ -48,13 +49,5 @@ export function isLibraryCompatible(rules?: Rule[], natives?: Natives): boolean 
  * @param {string} actual The actual version.
  */
 export function mcVersionAtLeast(desired: string, actual: string): boolean {
-    const des = desired.split('.')
-    const act = actual.split('.')
-
-    for(let i=0; i<des.length; i++){
-        if(!(parseInt(act[i]) >= parseInt(des[i]))){
-            return false
-        }
-    }
-    return true
+    return semver.satisfies(actual, `>=${desired}`)
 }


### PR DESCRIPTION
Changed the mcVersionAtLeast function to use semver.satisfies to allow patch versions to be matched