### PR TITLE
Fix: Proper Handling of `supported` Property in Java Options

### DIFF
--- a/lib/common/distribution/DistributionFactory.ts
+++ b/lib/common/distribution/DistributionFactory.ts
@@ -124,7 +124,7 @@ export class HeliosServer {
     private defaultUndefinedJavaOptions(props: JavaVersionProps): Required<JavaVersionProps> {
         const [defaultRange, defaultSuggestion] = this.defaultJavaVersion()
         return {
-            supported: props.distribution ?? defaultRange,
+            supported: props.supported ?? defaultRange,
             distribution: props.distribution ?? this.defaultJavaPlatform(),
             suggestedMajor: props.suggestedMajor ?? defaultSuggestion,
         }


### PR DESCRIPTION
## Fix: Proper Handling of `supported` Property in Java Options

### Summary
- Replaced `props.distribution ?? defaultRange` with `props.supported ?? defaultRange` to correctly handle the `supported` property when defaulting Java options.
- Ensured the logic in `defaultUndefinedJavaOptions` aligns with the updated property names.

This change resolves inconsistencies in how the `supported` property is handled within Java version configurations.

---

### Additional Context for the Fix

I discovered this issue while adding the `javaOptions` property to my server's configuration. After parsing the distribution file using `helios-core`, the Java version constraint I defined (`>=22.x`) was unexpectedly changed to `>=21.x` in the parsed version.

This behavior is incorrect, as the parsed configuration should preserve the original `semver` constraints exactly as specified in the distribution file.

This fix ensures that the `supported` property retains the intended version constraints without modification during parsing.

---

### Evidence

![image](https://github.com/user-attachments/assets/88a7f908-56c5-4618-a0d7-dbbe2900ff9f)
