### PR TITLE
fix: helios-core not requesting a new refresh token

### DIFF
--- a/lib/microsoft/rest/MicrosoftAuth.ts
+++ b/lib/microsoft/rest/MicrosoftAuth.ts
@@ -173,7 +173,7 @@ export class MicrosoftAuth {
 
             const BASE_FORM: AbstractTokenRequest = {
                 client_id: clientId,
-                scope: 'XboxLive.signin',
+                scope: 'XboxLive.signin offline_access',
                 redirect_uri: 'https://login.microsoftonline.com/common/oauth2/nativeclient',
             }
 


### PR DESCRIPTION
Users had to log back in every other time the token was refreshed, as Helios was not requesting a new refresh token